### PR TITLE
fix(ci): add permission for GH token to write to repo

### DIFF
--- a/.github/workflows/jsify.yml
+++ b/.github/workflows/jsify.yml
@@ -6,6 +6,11 @@ on:
 jobs:
   jvs-update:
     runs-on: ubuntu-latest
+
+    # Required for git-auto-commit-action to write to the repository
+    permissions:
+      contents: write
+
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
git-auto-commit-action does not work and gets a 403 because the GH token does not have write access to the repository, so this commit gives it permission to.