### PR TITLE
autofocus search field

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     <label for="pickle">pickle mode</label>
   </p>
   <p>
-    <input type="text" id="search" />
+    <input autofocus type="text" id="search" />
     <span id="len"></span>
   </p>
   <div id="results"></div>


### PR DESCRIPTION
this PR adds the `autofocus` attribute to the search box, making it so há can search right away by typing once the page loads.

according to [this discussion on stacköverflow](https://stackoverflow.com/questions/2180645/is-automatically-assigning-focus-bad-for-accessibility) autofocusing input fields isn't *necessarily* bad for a11y if it's expected that typing into ínputfield is the primary purpose of the page, which in this case it is.